### PR TITLE
Prevent Players Having Empty Nicknames

### DIFF
--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/MetaManager.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/MetaManager.java
@@ -46,7 +46,7 @@ public class MetaManager {
 				displayNameFormat = displayNameFormat.replaceAll("%NAME%", playername);
 				displayNameFormat = displayNameFormat.replaceAll("%PREFIX%", chat.getPlayerPrefix(Bukkit.getPlayer(playername)));
 				displayNameFormat = displayNameFormat.replaceAll("%SUFFIX%", chat.getPlayerSuffix(Bukkit.getPlayer(playername)));
-				displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "ง");
+				displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "ยง");
 
 				Bukkit.getPlayer(playername).setDisplayName(displayNameFormat);
 				Bukkit.getPlayer(playername).setPlayerListName(displayNameFormat);
@@ -57,7 +57,7 @@ public class MetaManager {
 
 				displayNameFormat = displayNameFormat.replaceAll("%NICK%", nickname);
 				displayNameFormat = displayNameFormat.replaceAll("%NAME%", playername);
-				displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "ง");
+				displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "ยง");
 
 				Bukkit.getPlayer(playername).setDisplayName(displayNameFormat);
 				Bukkit.getPlayer(playername).setPlayerListName(displayNameFormat);

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/MultiChatSpigot.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/MultiChatSpigot.java
@@ -87,6 +87,7 @@ public class MultiChatSpigot extends JavaPlugin implements Listener {
 	public static String nicknamePrefix = "~";
 	public static List<String> nicknameBlacklist = new ArrayList<String>();
 	public static int nicknameMaxLength = 20;
+	public static int nicknameMinLength = 3;
 	public static boolean nicknameLengthIncludeFormatting = false;
 
 	@SuppressWarnings("unchecked")
@@ -132,6 +133,10 @@ public class MultiChatSpigot extends JavaPlugin implements Listener {
 				nicknameMaxLength = config.getInt("nickname_length_limit");
 				nicknameLengthIncludeFormatting = config.getBoolean("nickname_length_limit_formatting");
 				
+			}
+			
+			if(config.contains("nickname_length_min")) {
+				nicknameMinLength = config.getInt("nickname_length_min");
 			}
 		}
 

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -158,7 +158,7 @@ public class CommandHandler implements CommandExecutor {
 
 					}
 					
-					if(args[0].length() > MultiChatSpigot.nicknameMinLength || sender.hasPermission("multichatspigot.nick.anylength")) {
+					if(args[0].length() < MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
 					
 						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Including format codes)");
 						return true;
@@ -174,7 +174,7 @@ public class CommandHandler implements CommandExecutor {
 
 					}
 					
-					if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() > MultiChatSpigot.nicknameMinLength  || sender.hasPermission("multichatspigot.nick.anylength")) {
+					if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() < MultiChatSpigot.nicknameMinLength  && !sender.hasPermission("multichatspigot.nick.anylength")) {
 						
 						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Excluding format codes)");
 						return true;

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -270,7 +270,7 @@ public class CommandHandler implements CommandExecutor {
 				
 				if (args[1].length() < MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
 
-					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMaxLength + " characters! (Including format codes)");
+					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Including format codes)");
 					return true;
 
 				}
@@ -283,7 +283,7 @@ public class CommandHandler implements CommandExecutor {
 
 				}
 				
-				if (NameManager.getInstance().stripAllFormattingCodes(args[1]).length() < MultiChatSpigot.nicknameMaxLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+				if (NameManager.getInstance().stripAllFormattingCodes(args[1]).length() < MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
 
 					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Excluding format codes)");
 					return true;

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -143,7 +143,7 @@ public class CommandHandler implements CommandExecutor {
 					return true;
 				}
 
-				//Make sure nickname is not just a formatting codes and would appear empty
+				//Make sure nickname is not formatting codes that would appear empty
 				if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() < 1) {
 					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname cannot be empty.");
 					return true;

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -267,11 +267,25 @@ public class CommandHandler implements CommandExecutor {
 					return true;
 
 				}
+				
+				if (args[1].length() < MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+
+					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMaxLength + " characters! (Including format codes)");
+					return true;
+
+				}
 			} else {
 				// Do not include formatting codes in the nickname length
 				if (NameManager.getInstance().stripAllFormattingCodes(args[1]).length() > MultiChatSpigot.nicknameMaxLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
 
 					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too long, max " + MultiChatSpigot.nicknameMaxLength + " characters! (Excluding format codes)");
+					return true;
+
+				}
+				
+				if (NameManager.getInstance().stripAllFormattingCodes(args[1]).length() < MultiChatSpigot.nicknameMaxLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+
+					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Excluding format codes)");
 					return true;
 
 				}

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -158,7 +158,7 @@ public class CommandHandler implements CommandExecutor {
 
 					}
 					
-					if(args[0].length() > MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+					if(args[0].length() > MultiChatSpigot.nicknameMinLength || sender.hasPermission("multichatspigot.nick.anylength")) {
 					
 						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Including format codes)");
 						return true;
@@ -174,7 +174,7 @@ public class CommandHandler implements CommandExecutor {
 
 					}
 					
-					if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() > MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+					if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() > MultiChatSpigot.nicknameMinLength  || sender.hasPermission("multichatspigot.nick.anylength")) {
 						
 						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Excluding format codes)");
 						return true;

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spigotbridge/commands/CommandHandler.java
@@ -143,6 +143,12 @@ public class CommandHandler implements CommandExecutor {
 					return true;
 				}
 
+				//Make sure nickname is not just a formatting codes and would appear empty
+				if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() < 1) {
+					sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname cannot be empty.");
+					return true;
+				}
+				
 				if (MultiChatSpigot.nicknameLengthIncludeFormatting) {
 					// Include formatting codes in the nickname length
 					if (args[0].length() > MultiChatSpigot.nicknameMaxLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
@@ -151,6 +157,14 @@ public class CommandHandler implements CommandExecutor {
 						return true;
 
 					}
+					
+					if(args[0].length() > MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+					
+						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Including format codes)");
+						return true;
+						
+					}
+					
 				} else {
 					// Do not include formatting codes in the nickname length
 					if (NameManager.getInstance().stripAllFormattingCodes(args[0]).length() > MultiChatSpigot.nicknameMaxLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
@@ -159,8 +173,15 @@ public class CommandHandler implements CommandExecutor {
 						return true;
 
 					}
+					
+					if(NameManager.getInstance().stripAllFormattingCodes(args[0]).length() > MultiChatSpigot.nicknameMinLength && !sender.hasPermission("multichatspigot.nick.anylength")) {
+						
+						sender.sendMessage(ChatColor.DARK_RED + "Sorry your nickname is too short, min " + MultiChatSpigot.nicknameMinLength + " characters! (Excluding format codes)");
+						return true;
+						
+					}
 				}
-
+				
 				String targetNickname = NameManager.getInstance().stripAllFormattingCodes(NameManager.getInstance().getCurrentName(targetUUID));
 				String targetName = NameManager.getInstance().getName(targetUUID);
 

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spongebridge/MultiChatSponge.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spongebridge/MultiChatSponge.java
@@ -330,7 +330,7 @@ public final class MultiChatSponge implements CommandExecutor {
 			displayNameFormat = displayNameFormat.replaceAll("%NAME%", playername);
 			displayNameFormat = displayNameFormat.replaceAll("%PREFIX%", prefix);
 			displayNameFormat = displayNameFormat.replaceAll("%SUFFIX%", suffix);
-			displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "§");
+			displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "ï¿½");
 
 			final String finalDisplayName = displayNameFormat;
 
@@ -371,6 +371,11 @@ public final class MultiChatSponge implements CommandExecutor {
 
 		String strippedNickname = stripAllFormattingCodes(nickname);
 
+		if(strippedNickname.length() < 1) {
+			sender.sendMessage(Text.of("Sorry, your nickname cannot be empty."));
+			return CommandResult.success();
+		}
+		
 		UserStorageService uss = Sponge.getServiceManager().provideUnchecked(UserStorageService.class);
 		Optional<User> lookedUpName = uss.get(strippedNickname);
 

--- a/multichat/src/main/java/xyz/olivermartin/multichat/spongebridge/MultiChatSponge.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/spongebridge/MultiChatSponge.java
@@ -330,7 +330,7 @@ public final class MultiChatSponge implements CommandExecutor {
 			displayNameFormat = displayNameFormat.replaceAll("%NAME%", playername);
 			displayNameFormat = displayNameFormat.replaceAll("%PREFIX%", prefix);
 			displayNameFormat = displayNameFormat.replaceAll("%SUFFIX%", suffix);
-			displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "�");
+			displayNameFormat = displayNameFormat.replaceAll("&(?=[a-f,0-9,k-o,r])", "§");
 
 			final String finalDisplayName = displayNameFormat;
 

--- a/multichat/src/main/resources/spigotconfig.yml
+++ b/multichat/src/main/resources/spigotconfig.yml
@@ -22,7 +22,7 @@ version: "1.7.3" #
 override_global_format: false
 
 # The format to use for the global chat if the setting above is set to true
-# 
+#
 # USES STANDARD MINECRAFT '&X' COLOUR/FORMAT CODES
 # %NAME% = The name of the sender
 # %DISPLAYNAME% = The display name of the sender
@@ -38,7 +38,7 @@ override_global_format_format: "&5[&dG&5] &f%DISPLAYNAME%&f: "
 # If the setting below is set to true, then regardless of the settings above, MultiChat will NOT touch the chat format.
 # This means that if a plugin such as Towny manages the chat format locally, then this will be used instead.
 # MultiChat will still send the message to all the other servers.
-# 
+#
 # NOTE: THIS IS DONE ON A BEST EFFORT BASIS! (MultiChat is a chat formatting plugin so is designed to format the chat!)
 override_all_multichat_formatting: false
 
@@ -56,7 +56,7 @@ force_multichat_format: false
 set_local_format: true
 
 # The local chat format to set if MultiChat is to manage the format
-# 
+#
 # USES STANDARD MINECRAFT '&X' COLOUR/FORMAT CODES
 # %NAME% = The name of the sender
 # %DISPLAYNAME% = The display name of the sender
@@ -106,6 +106,9 @@ nickname_prefix: "~"
 
 # The maximum length for nicknames
 nickname_length_limit: 20
+
+# Minimium length for nicknames
+nickname_length_min: 3
 
 # Should formatting codes such as "&3" be counted in the length of the nickname?
 nickname_length_limit_formatting: false


### PR DESCRIPTION
# Description
On a server where normal users are allowed color or formatting codes in their name, `/nick &1` is a valid nickname that results in the player having no displayed nickname in chat. The only way to figure out who has done this is by manually checking every `/realname &[1-9,a-f]` until you find the culprit.

## What, briefly, is the purpose of this pull request?
- Stop people from setting display-less nicknames.
- Since it was sort of related, add a config option to specify a minimum nickname length.

### Is this pull request related to an issue with the plugin?
Nothing is outright broken, but it's an irritating situation to deal with.

## What is the status of this pull request? [e.g. In Development, Undergoing Final Testing, Ready]
Ready

# Changes

## What currently existing parts of the plugin are affected by this pull request
- Spigot config
- Spigot `/nick` command processing
- Sponge `/nick` command processing

## What new features are added to the plugin by this pull request
- Add check to `/nick`. Looks for non-formatting text.
- Add check to `/nick`. Looks for nickname length greater than configured minimum. Respects `multichat.nick.anylength` permission, config option `nickname_length_min`)

# Standards

## Does this pull request adhere to basic Java coding standards?
Yes

## Is the pull request suitably javadoc'd? (E.g. Have you written detailed javadoc on all public methods)
Yes

## Does this pull request seem to stay true to the style used so far in the MultiChat code.
No


