### PR TITLE
Fix global message sender thread deadlock

### DIFF
--- a/multichat/src/main/java/xyz/olivermartin/multichat/bungee/BungeeComm.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/bungee/BungeeComm.java
@@ -227,12 +227,8 @@ public class BungeeComm implements Listener {
 
 				DebugManager.log("{multichat:chat} Got player successfully! Name = " + player.getName());
 
-				synchronized (player) {
-
-					DebugManager.log("{multichat:chat} Global Channel Available? = " + (Channel.getGlobalChannel() != null));
-					Channel.getGlobalChannel().sendMessage(player, message, format);
-
-				}
+				DebugManager.log("{multichat:chat} Global Channel Available? = " + (Channel.getGlobalChannel() != null));
+				Channel.getGlobalChannel().sendMessage(player, message, format);
 
 			} catch (IOException e) {
 				DebugManager.log("{multichat:chat} ERROR READING PLUGIN MESSAGE");


### PR DESCRIPTION
Please do not submit major pull requests without first discussing them with me. Contact me on Discord (https://discord.gg/PVreERC) or otherwise.

# Description

## What, briefly, is the purpose of this pull request?
Fix of Netty threads deadlock, causing Bungeecord to stop after ~1 hour (with ~100 players).

### Is this pull request related to an issue with the plugin?
No

## What is the status of this pull request? [e.g. In Development, Undergoing Final Testing, Ready]
Ready

# Changes

## What currently existing parts of the plugin are affected by this pull request
Dispatch of sending global messages.

## What new features are added to the plugin by this pull request
I've removed lock of sender, which is also locked inside sendMessage method on other threads. I am aware, that sender in theory could change. In practice, nothing bad should happen. Anyway, it is still better than locking Netty thread.

# Standards

## Does this pull request adhere to basic Java coding standards?
Yes

## Is the pull request suitably javadoc'd? (E.g. Have you written detailed javadoc on all public methods)
Yes (no new/deleted methods)

## Does this pull request seem to stay true to the style used so far in the MultiChat code.
Yes


# My annotation

Here is crashlog from Bungee:
```
"Netty Worker IO Thread #2" - Thread t@69
   java.lang.Thread.State: BLOCKED
        at xyz.olivermartin.multichat.bungee.Channel.sendMessage(Channel.java:147)
        - waiting to lock <76b00559> (a net.md_5.bungee.UserConnection) owned by "Netty Worker IO Thread #3" t@70
        at xyz.olivermartin.multichat.bungee.BungeeComm.onPluginMessage(BungeeComm.java:233)
        - locked <7e22193e> (a net.md_5.bungee.UserConnection)
        at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source)

"Netty Worker IO Thread #3" - Thread t@70
   java.lang.Thread.State: BLOCKED
        at xyz.olivermartin.multichat.bungee.Channel.sendMessage(Channel.java:147)
        - waiting to lock <7e22193e> (a net.md_5.bungee.UserConnection) owned by "Netty Worker IO Thread #2" t@69
        at xyz.olivermartin.multichat.bungee.BungeeComm.onPluginMessage(BungeeComm.java:233)
        - locked <76b00559> (a net.md_5.bungee.UserConnection)
```