### PR TITLE
Correct construction of PostGlobalChatEvent object

### DIFF
--- a/multichat/src/main/java/xyz/olivermartin/multichat/bungee/Channel.java
+++ b/multichat/src/main/java/xyz/olivermartin/multichat/bungee/Channel.java
@@ -201,7 +201,7 @@ public class Channel {
 				);*/
 
 		// Trigger PostGlobalChatEvent
-		ProxyServer.getInstance().getPluginManager().callEvent(new PostGlobalChatEvent(sender, message, format));
+		ProxyServer.getInstance().getPluginManager().callEvent(new PostGlobalChatEvent(sender, format, message));
 
 		sendToConsole(sender,format,message);
 


### PR DESCRIPTION
# Description

The PostGlobalChatEvent object has constructor `public PostGlobalChatEvent(ProxiedPlayer sender, String format, String message)`

Corrected in Channel.java to call constructor with correctly ordered parameter

Tested on our server event now correctly constructed as far as I can tell with intellij's debugger.

# Changes

The PostGlobalChatEvent object has constructor `public PostGlobalChatEvent(ProxiedPlayer sender, String format, String message)`

Corrected in Channel.java to call constructor with correctly ordered parameter

# Standards

Abides by all current formatting. No JDocs required.
